### PR TITLE
Fix font color of logo

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -49,7 +49,7 @@ p {
   float: left;
   margin-right: 10px;
   font-size: 1.7em;
-  color: #000;
+  color: #999;
   text-transform: uppercase;
   letter-spacing: -1px;
   padding-top: 9px;


### PR DESCRIPTION
The font color of the logo text and the background both are black. Due to this, the logo gets hidden and is only revealed on hover. I changed the text to a lighter color to fix it.
